### PR TITLE
feat: create reusable drawer and add to home page

### DIFF
--- a/lib/models/page.dart
+++ b/lib/models/page.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+class Page {
+  Page({this.icon, this.route, this.title});
+
+  final Icon icon;
+  final String route;
+  final String title;
+}

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -1,3 +1,4 @@
+import 'package:avon_farm_foods/widgets/drawer.dart';
 import 'package:flutter/material.dart';
 
 class HomePage extends StatefulWidget {
@@ -68,6 +69,7 @@ class _HomePageState extends State<HomePage> {
         ],
         padding: new EdgeInsets.all(16.0),
       ),
+      drawer: new DrawerWidget(),
     );
   }
 }

--- a/lib/widgets/drawer.dart
+++ b/lib/widgets/drawer.dart
@@ -1,0 +1,47 @@
+import 'package:avon_farm_foods/models/page.dart';
+import 'package:avon_farm_foods/widgets/drawer_page.dart';
+import 'package:flutter/material.dart';
+
+class DrawerWidget extends StatelessWidget {
+  final List<Page> _pages = [
+    new Page(
+      icon: new Icon(Icons.home),
+      route: 'home',
+      title: 'Home',
+    ),
+    new Page(
+      icon: new Icon(Icons.search),
+      route: 'products',
+      title: 'Products',
+    ),
+    new Page(
+      icon: new Icon(Icons.shopping_basket),
+      route: 'basket',
+      title: 'Basket',
+    ),
+    new Page(
+      icon: new Icon(Icons.receipt),
+      route: 'orders',
+      title: 'Orders',
+    ),
+    new Page(
+      icon: new Icon(Icons.settings),
+      route: 'settings',
+      title: 'Settings',
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return new Drawer(
+      child: new ListView(
+        children: _pages.map((Page page) {
+          return new DrawerPageWidget(
+            onTap: () => Navigator.of(context).pushNamed(page.route),
+            page: page,
+          );
+        }).toList(),
+      ),
+    );
+  }
+}

--- a/lib/widgets/drawer_page.dart
+++ b/lib/widgets/drawer_page.dart
@@ -1,0 +1,29 @@
+import 'package:avon_farm_foods/models/page.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class DrawerPageWidget extends StatefulWidget {
+  DrawerPageWidget({
+    Key key,
+    @required this.onTap,
+    @required this.page,
+  })
+      : super(key: key);
+
+  final VoidCallback onTap;
+  final Page page;
+
+  @override
+  _DrawerPageWidgetState createState() => new _DrawerPageWidgetState();
+}
+
+class _DrawerPageWidgetState extends State<DrawerPageWidget> {
+  @override
+  Widget build(BuildContext context) {
+    return new ListTile(
+      leading: widget.page.icon,
+      onTap: widget.onTap,
+      title: new Text(widget.page.title),
+    );
+  }
+}


### PR DESCRIPTION
## Pull Request Checklist
<!-- Check if your pull request fulfills the requirements. -->
- [x] Commit Message Follows Guidelines
- [ ] Tests For Changes Have Been Added
- [ ] Docs Have Been Added Or Updated

## Current Behaviour
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The user is stuck on the home page with no means of navigation to any other page.

## New Behaviour
<!-- Please describe the new behavior that you have implemented. -->
A drawer has been created which will allow the user to switch between multiple pages.
